### PR TITLE
Fix/issue88

### DIFF
--- a/ResearchKit/Common/ORKAutocompleteStepView.m
+++ b/ResearchKit/Common/ORKAutocompleteStepView.m
@@ -58,6 +58,8 @@
     
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
+    self.stepViewFillsAvailableSpace = YES;
+    self.verticalCenteringEnabled = YES;
     
     [self filterSearchTerms];
     

--- a/ResearchKit/Common/ORKAutocompleteStepViewController.m
+++ b/ResearchKit/Common/ORKAutocompleteStepViewController.m
@@ -19,6 +19,7 @@
 @interface ORKAutocompleteStepViewController () <ORKSurveyAnswerCellDelegate>
 
 @property (nonatomic) ORKAutocompleteStepView *autocompleteStepView;
+@property (nonatomic) NSLayoutConstraint *autocompleteStepViewHeightConstraint;
 
 @end
 
@@ -27,13 +28,32 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    CGRect frame = CGRectMake(0, 0, self.view.bounds.size.width, self.view.bounds.size.height * 0.48);
+    CGRect frame = self.view.bounds;
     self.autocompleteStepView = [[ORKAutocompleteStepView alloc] initWithFrame:frame];
     self.autocompleteStepView.answerDelegate = self;
     self.autocompleteStepView.autocompleteStep = [self autocompleteStep];
     
     self.autocompleteStepView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
     [self setCustomQuestionView:(ORKQuestionStepCustomView *)self.autocompleteStepView];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    
+    if ( self.autocompleteStepViewHeightConstraint == nil )
+    {
+        NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self.autocompleteStepView
+                                                                      attribute:NSLayoutAttributeHeight
+                                                                      relatedBy:NSLayoutRelationEqual
+                                                                         toItem:nil
+                                                                      attribute:NSLayoutAttributeNotAnAttribute
+                                                                     multiplier:1.0
+                                                                       constant:self.autocompleteStepView.frame.size.height];
+        [self.autocompleteStepView addConstraint:constraint];
+        self.autocompleteStepViewHeightConstraint = constraint;
+    }
+    
 }
 
 - (ORKAutocompleteStep *)autocompleteStep

--- a/ResearchKit/Common/ORKAutocompleteStepViewController.m
+++ b/ResearchKit/Common/ORKAutocompleteStepViewController.m
@@ -19,7 +19,8 @@
 @interface ORKAutocompleteStepViewController () <ORKSurveyAnswerCellDelegate>
 
 @property (nonatomic) ORKAutocompleteStepView *autocompleteStepView;
-@property (nonatomic) NSLayoutConstraint *autocompleteStepViewHeightConstraint;
+
+@property (nonatomic) BOOL keyboardWasPresentedAtLeastOnce;
 
 @end
 
@@ -35,13 +36,33 @@
     
     self.autocompleteStepView.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
     [self setCustomQuestionView:(ORKQuestionStepCustomView *)self.autocompleteStepView];
+    
+    [self registerForKeyboardNotifications:YES];
 }
 
-- (void)viewDidAppear:(BOOL)animated
+- (void)dealloc
 {
-    [super viewDidAppear:animated];
-    
-    if ( self.autocompleteStepViewHeightConstraint == nil )
+    [self registerForKeyboardNotifications:NO];
+}
+
+- (void)registerForKeyboardNotifications:(BOOL)shouldRegister
+{
+    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+    if (shouldRegister)
+    {
+        [notificationCenter addObserver:self
+                               selector:@selector(keyboardWillShow:)
+                                   name:UIKeyboardWillShowNotification object:nil];
+    }
+    else
+    {
+        [notificationCenter removeObserver:self name:UIKeyboardWillShowNotification object:nil];
+    }
+}
+
+- (void)keyboardWillShow:(NSNotification *)notification
+{
+    if ( !self.keyboardWasPresentedAtLeastOnce )
     {
         NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self.autocompleteStepView
                                                                       attribute:NSLayoutAttributeHeight
@@ -51,9 +72,9 @@
                                                                      multiplier:1.0
                                                                        constant:self.autocompleteStepView.frame.size.height];
         [self.autocompleteStepView addConstraint:constraint];
-        self.autocompleteStepViewHeightConstraint = constraint;
     }
     
+    self.keyboardWasPresentedAtLeastOnce = YES;
 }
 
 - (ORKAutocompleteStep *)autocompleteStep


### PR DESCRIPTION
This addresses a layout issue with autocomplete steps.

It was particularly thorny given table/phone scenarios and the intricacies of ResearchKit view hierarchy.

The solution is to establish a height constraint on the custom step view (the autocomplete table) and ensure that it maintains a proper height as different components will try to adjust it based on available screen space.

My expectation from RK would be that this line alone should accomplish this:
```objectivec
self.stepViewFillsAvailableSpace = YES;
```
But that is not the case.