### PR TITLE
Do not display empty responses on form review steps

### DIFF
--- a/ResearchKit/Common/ORKReviewStepViewController.m
+++ b/ResearchKit/Common/ORKReviewStepViewController.m
@@ -210,7 +210,8 @@
                 if (formItem.answerFormat && [questionResult isKindOfClass:formItem.answerFormat.questionResultClass] && questionResult.answer) {
                     NSString *formItemTextString = formItem.text;
                     NSString *formItemAnswerString = [formItem.answerFormat stringForAnswer:questionResult.answer];
-                    if (formItemTextString && formItemAnswerString) {
+                    if (formItemTextString && formItemAnswerString && formItemAnswerString.length > 0 && ![formItemAnswerString isEqualToString:ORKLocalizedString(@"NULL_ANSWER", nil)])
+                    {
                         [answerStrings addObject:[@[formItemTextString, formItemAnswerString] componentsJoinedByString:@"\n"]];
                     }
                 }


### PR DESCRIPTION
Form steps are displaying the titles with empty values when there is an empty array as response, or when the field has the default null response from RK. So we need to test those conditions too.