### PR TITLE
remove header import which breaks client builds

### DIFF
--- a/ResearchKit/ResearchKit.h
+++ b/ResearchKit/ResearchKit.h
@@ -108,5 +108,4 @@
 // Extra headers
 #import <ResearchKit/MDRTextInputFeedback.h>
 #import <ResearchKit/ORKAutocompleteStep.h>
-#import <ResearchKit/ORKAutocompleteStepViewController.h>
 // Medable ---


### PR DESCRIPTION
RK itself built fine with this, but AxonSDK doesn't and it doesn't appear to be needed.