### PR TITLE
PAT-37: Merge pull request #1064 from CareEvolution/camera-layout

### DIFF
--- a/ResearchKit/Common/ORKImageCaptureCameraPreviewView.m
+++ b/ResearchKit/Common/ORKImageCaptureCameraPreviewView.m
@@ -78,6 +78,15 @@
 - (void)setUpConstraints {
     NSMutableArray *constraints = [NSMutableArray new];
     
+    [_templateImageView setContentHuggingPriority:0 forAxis:UILayoutConstraintAxisHorizontal];
+    [_templateImageView setContentHuggingPriority:0 forAxis:UILayoutConstraintAxisVertical];
+    [_templateImageView setContentCompressionResistancePriority:0 forAxis:UILayoutConstraintAxisHorizontal];
+    [_templateImageView setContentCompressionResistancePriority:0 forAxis:UILayoutConstraintAxisVertical];
+    [_capturedImageView setContentHuggingPriority:0 forAxis:UILayoutConstraintAxisHorizontal];
+    [_capturedImageView setContentHuggingPriority:0 forAxis:UILayoutConstraintAxisVertical];
+    [_capturedImageView setContentCompressionResistancePriority:0 forAxis:UILayoutConstraintAxisHorizontal];
+    [_capturedImageView setContentCompressionResistancePriority:0 forAxis:UILayoutConstraintAxisVertical];
+    
     // Make the insets for the template image view changeable later
     _templateImageViewTopInsetConstraint = [NSLayoutConstraint constraintWithItem:_templateImageView
                                                               attribute:NSLayoutAttributeTop

--- a/ResearchKit/Common/ORKImageCaptureView.m
+++ b/ResearchKit/Common/ORKImageCaptureView.m
@@ -215,7 +215,7 @@
                                                                                         views:views]];
     
     [_variableConstraints addObjectsFromArray:
-     [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_headerView]-[_continueSkipContainer]|"
+     [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_headerView]-(>=0)-|"
                                              options:NSLayoutFormatDirectionLeadingToTrailing
                                              metrics:nil
                                                views:views]];


### PR DESCRIPTION
Make the ORKImageCaptureCameraPreviewView take the full width of the screen.

(confirmed, works as advertised)