### PR TITLE
Consent Review - Signature is displayed above the line within the generated PDF

### DIFF
--- a/ResearchKit/Common/ORKSignatureView.m
+++ b/ResearchKit/Common/ORKSignatureView.m
@@ -464,17 +464,23 @@ static CGPoint mmid_Point(CGPoint p1, CGPoint p2) {
     CGSize imageContextSize;
     imageContextSize = (self.bounds.size.width == 0 || self.bounds.size.height == 0) ? CGSizeMake(200, 200) :
                         self.bounds.size;
+    
     UIGraphicsBeginImageContext(imageContextSize);
-
+    
+    CGRect rect = CGRectNull;
     for (UIBezierPath *path in self.pathArray) {
+        rect = CGRectUnion(rect, path.bounds);
         [self.lineColor setStroke];
         [path stroke];
     }
     
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    
+    rect = CGRectInset(rect, -10, -10); // a small margin
+    CGImageRef crop = CGImageCreateWithImageInRect(image.CGImage, rect);
     UIGraphicsEndImageContext();
     
-    return image;
+    return [[UIImage alloc] initWithCGImage:crop];
 }
 
 - (BOOL)signatureExists {

--- a/ResearchKit/Consent/ORKConsentDocument.m
+++ b/ResearchKit/Consent/ORKConsentDocument.m
@@ -145,12 +145,16 @@
         [css appendString:@"body, p, h1, h2, h3 { font-family: Helvetica; }\n"];
     }
     
-    [css appendFormat:@".col-1-3 { width: %@; float: left; padding-right: 20px; }\n", mobile ? @"66.6%" : @"33.3%"];
-    [css appendString:@".sigbox { position: relative; height: 100px; max-height:100px; display: inline-block; bottom: 10px }\n"];
-    [css appendString:@".inbox { position: relative; top: 100%; transform: translateY(-100%); -webkit-transform: translateY(-100%);  }\n"];
+    // Medable >>>>>
+    [css appendFormat:@".col-1-3 { width: %@; float: left; padding-right: 20px; margin-top: 100px;}\n", mobile ? @"66.6%" : @"33.3%"];
+    // Use flexbox to bottom-align the signature image
+    [css appendString:@".sigbox { position: relative; height: 100px; max-height:100px; display: -webkit-box; display: -ms-flexbox; display: flex; bottom: 10px; -webkit-box-align: end; -ms-flex-align: end; align-items: flex-end; }\n"];
+    [css appendString:@".inbox { position: absolute; bottom:10px; top: 100%%; transform: translateY(-100%%); -webkit-transform: translateY(-100%%);  }\n"];
+    [css appendString:@".inboxImage { position: relative; bottom:0px; }\n"];
+    // Medable <<<<<
     [css appendString:@".grid:after { content: \"\"; display: table; clear: both; }\n"];
     [css appendString:@".border { -webkit-box-sizing: border-box; box-sizing: border-box; }\n"];
-    
+
     return css;
 }
 

--- a/ResearchKit/Consent/ORKConsentSignatureFormatter.m
+++ b/ResearchKit/Consent/ORKConsentSignatureFormatter.m
@@ -45,6 +45,8 @@
     NSString *hr = @"<hr align='left' width='100%' style='height:1px; border:none; color:#000; background-color:#000; margin-top: -10px; margin-bottom: 0px;' />";
 
     NSString *signatureElementWrapper = @"<p><br/><div class='sigbox'><div class='inbox'>%@</div></div>%@%@</p>";
+    NSString *signatureImageWrapper = @"<p><br/><div class='sigbox'><div class='inboxImage'>%@</div></div>%@%@</p>";
+
 
     BOOL addedSig = NO;
 
@@ -87,7 +89,7 @@
             [body appendString:@"<br/>"];
         }
         NSString *titleFormat = ORKLocalizedString(@"CONSENT_DOC_LINE_SIGNATURE", nil);
-        [signatureElements addObject:[NSString stringWithFormat:signatureElementWrapper, imageTag ? : @"&nbsp;", hr, [NSString stringWithFormat:titleFormat, signature.title]]];
+        [signatureElements addObject:[NSString stringWithFormat:signatureImageWrapper, imageTag ? : @"&nbsp;", hr, [NSString stringWithFormat:titleFormat, signature.title]]];
     }
 
     if (addedSig) {


### PR DESCRIPTION
- Use the flexbox layout module to aling the signature to the bottom.
- Crop the signature to the actual signature, plus a small margin.