### PR TITLE
Create CODEOWNERS to specify required approvers.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require any changes to be approve by iOS approvers.
+*  @Medable/iosapprovers


### PR DESCRIPTION
Add a CODEOWNERS file to restrict reviews to the approvers team.