### PR TITLE
PATIOS-332: Image Selection: Some steps have a big empty space below the images

### DIFF
--- a/ResearchKit/Common/ORKImageSelectionView.m
+++ b/ResearchKit/Common/ORKImageSelectionView.m
@@ -105,13 +105,13 @@
                                                             attribute:NSLayoutAttributeWidth
                                                            multiplier:image.size.height / image.size.width
                                                              constant:0.0]];
-        // button's height <= image
+        // Limit button height to 100px or image height, whichever is smaller
         [constraints addObject:[NSLayoutConstraint constraintWithItem:_button
                                                             attribute:NSLayoutAttributeHeight
                                                             relatedBy:NSLayoutRelationLessThanOrEqual
                                                                toItem:nil attribute:NSLayoutAttributeHeight
                                                            multiplier:1.0
-                                                             constant:image.size.height]];
+                                                             constant:MIN(100, image.size.height)]];
     } else {
         // Keep Aspect ratio
         [constraints addObject:[NSLayoutConstraint constraintWithItem:_button


### PR DESCRIPTION
Limit image choice button height to 100px or image height, whichever is smaller

The height of the `ORKChoiceButtonView` in `ORKImageSelectionView`, and subsequently the height of `ORKSurveyAnswerCellForImageSelection` depends on the actual physical height of the image for each choice. In other words, if the image with resolution of 2000x1500px is used, the height of the button will be 1500px. This change limits the height to maximum of 100px.

Before:
![after](https://user-images.githubusercontent.com/56963239/96187299-0cf90480-0f3d-11eb-81f6-cc3339ebb3a7.png)

After:
![before](https://user-images.githubusercontent.com/56963239/96187293-0bc7d780-0f3d-11eb-8720-591f570535ec.png) 


PATIOS-332