### PR TITLE
AXONIOS-119 webview form, exposing questionResultClass

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.h
+++ b/ResearchKit/Common/ORKAnswerFormat.h
@@ -97,6 +97,8 @@ ORK_CLASS_AVAILABLE
 
 - (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer;
 
+- (nonnull Class)questionResultClass;
+
 /// @name Factory methods
 
 + (ORKScaleAnswerFormat *)scaleAnswerFormatWithMaximumValue:(NSInteger)scaleMaximum

--- a/ResearchKit/Common/ORKAnswerFormat_Internal.h
+++ b/ResearchKit/Common/ORKAnswerFormat_Internal.h
@@ -87,8 +87,6 @@ ORK_DESIGNATE_CODING_AND_SERIALIZATION_INITIALIZERS(ORKWeightAnswerFormat)
 
 - (nullable NSString *)localizedInvalidValueStringWithAnswerString:(nullable NSString *)text;
 
-- (nonnull Class)questionResultClass;
-
 - (ORKQuestionResult *)resultWithIdentifier:(NSString *)identifier answer:(id)answer;
 
 - (nullable NSString *)stringForAnswer:(id)answer;


### PR DESCRIPTION
Exposing `questionResultClass` for implying QuestionResult from ORKAnswerFormat.

`ORKAnswerFormat_Internal.h ` can't be set to public access because it imports private headers.