### PR TITLE
Remove negative inset

### DIFF
--- a/ResearchKit/Common/ORKFormItemCell.m
+++ b/ResearchKit/Common/ORKFormItemCell.m
@@ -893,7 +893,6 @@ static const CGFloat HorizontalMargin = 15.0;
     _textView = [[ORKFormTextView alloc] init];
     _textView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
     _textView.delegate = self;
-    _textView.contentInset = UIEdgeInsetsMake(-5.0, -4.0, -5.0, 0.0);
     _textView.textAlignment = NSTextAlignmentNatural;
     _textView.scrollEnabled = NO;
     _textView.placeholder = self.formItem.placeholder;


### PR DESCRIPTION
Placeholder text for textview that is a part of the form step is cut off because of the negative offset that was now removed.  
![IMG_0031](https://user-images.githubusercontent.com/43067532/109626840-e547b900-7b38-11eb-82ef-66e989bb7f9f.PNG)
