### PR TITLE
SITE-1311 Fix image loading on review step

### DIFF
--- a/ResearchKit/Common/ORKImageCaptureStepViewController.m
+++ b/ResearchKit/Common/ORKImageCaptureStepViewController.m
@@ -309,6 +309,8 @@
         [[NSFileManager defaultManager] removeItemAtURL:_fileURL error:nil];
         // Force the file to be rewritten the next time the result is requested
         _fileURL = nil;
+    } else if (_preserveImageDataOnRetakeAction) {
+        _fileURL = nil;
     }
     
     [self notifyDelegateOnResultChange];


### PR DESCRIPTION
Actual fix for SITE-1311 will be included within the Axon SDK. This additional change introduced with this PR is to handle image step comparison, because we use file URLs to compare old and new results. This change will force image to be resaved with different name so it can be compared with previous result - this allows us to present reason for change, and disable "Next" button if image is not recaptured.


https://user-images.githubusercontent.com/58979111/122610973-d1d94300-d080-11eb-92b1-d7c2564f14d3.mp4

