### PR TITLE
MESH-2551 / MESH-2553 : [Syneos_DaiiChi] - Fix el_GR Translations

### DIFF
--- a/ResearchKit/Localized/el-GR.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/el-GR.lproj/ResearchKit.strings
@@ -269,10 +269,10 @@
 "BUTTON_DISAGREE" = "Διαφωνώ";
 
 /* (No Comment) */
-"BUTTON_DONE" = "Έγινε";
+"BUTTON_DONE" = "Τέλος";
 
 /* (No Comment) */
-"BUTTON_GET_STARTED" = "Ξεκινήστε";
+"BUTTON_GET_STARTED" = "‘Εναρξη";
 
 /* (No Comment) */
 "BUTTON_LEARN_MORE" = "Μάθετε περισσότερα";


### PR DESCRIPTION
[Syneos_DaiiChi] - iOS - EORTC QLQ-C30 Done button is not correctly translated (el_GR)
[Syneos_DaiiChi] - iOS - EORTC QLQ-C30 and EORTC QLQ-LC13 Get started button is not correctly translated (el_GR)