### PR TITLE
MESH-3583 : [Syneos/GSK_B_Sure_gsk206882] - iOS - Align the step description text with the button labels (es_ES)

### DIFF
--- a/ResearchKit/Common/ORKCompletionStepViewController.m
+++ b/ResearchKit/Common/ORKCompletionStepViewController.m
@@ -146,6 +146,17 @@ static const CGFloat TickViewSize = 122;
     ORKCompletionStepView *_completionStepView;
 }
 
+- (void)initializeInternalButtonItems
+{
+    [super initializeInternalButtonItems];
+    
+    NSString *doneButtonTitle = ORKLocalizedString(@"COMPLETION_BUTTON_DONE", nil);
+    
+    if(![doneButtonTitle isEqualToString:@"COMPLETION_BUTTON_DONE"]) {
+        self.continueButtonTitle = doneButtonTitle;
+    }
+}
+
 - (void)stepDidChange {
     [super stepDidChange];
     

--- a/ResearchKit/Localized/es.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/es.lproj/ResearchKit.strings
@@ -204,7 +204,7 @@
 "BUTTON_APPLY" = "Aplicar";
 "BUTTON_DISAGREE" = "No acepto";
 "BUTTON_DONE" = "OK";
-"COMPLETION_BUTTON_DONE" = "LISTO";
+"COMPLETION_BUTTON_DONE" = "Listo";
 "BUTTON_GET_STARTED" = "Empezar";
 "BUTTON_LEARN_MORE" = "Más información";
 "BUTTON_NEXT" = "Siguiente";

--- a/ResearchKit/Localized/es.lproj/ResearchKit.strings
+++ b/ResearchKit/Localized/es.lproj/ResearchKit.strings
@@ -204,6 +204,7 @@
 "BUTTON_APPLY" = "Aplicar";
 "BUTTON_DISAGREE" = "No acepto";
 "BUTTON_DONE" = "OK";
+"COMPLETION_BUTTON_DONE" = "LISTO";
 "BUTTON_GET_STARTED" = "Empezar";
 "BUTTON_LEARN_MORE" = "Más información";
 "BUTTON_NEXT" = "Siguiente";


### PR DESCRIPTION
Update the translation of the "DONE" button, but only in completion steps and only if said new translation is available.