### PR TITLE
[NNS-4933]Force right alignment on scale description label

### DIFF
--- a/ResearchKit/Common/ORKScaleSliderView.m
+++ b/ResearchKit/Common/ORKScaleSliderView.m
@@ -194,6 +194,15 @@
         _slider.translatesAutoresizingMaskIntoConstraints = NO;
         
         [self setUpConstraints];
+        
+        // NNS-4933 this is a fix that forces the _rightRangeDescriptionLabel to be right aligned
+        if (!isVertical) {
+            NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
+            [style setAlignment:NSTextAlignmentRight];
+            NSAttributedString *attributedText = [[NSMutableAttributedString alloc] initWithString:_rightRangeDescriptionLabel.text
+                                                                                   attributes:@{NSParagraphStyleAttributeName: style}];
+            _rightRangeDescriptionLabel.attributedText = attributedText;
+        }
     }
     return self;
 }


### PR DESCRIPTION
_rightRangeDescriptionLabel has NSTextAlignmentRight set but it doesn't work. I've tried various things but nothing helps other than to set an attributed text that has a paragraph style set to NSTextAlignmentRight