### PR TITLE
PATIOS-3679 Additional Gregorian Calendar updates

### DIFF
--- a/ResearchKit/Common/ORKAnswerFormat.m
+++ b/ResearchKit/Common/ORKAnswerFormat.m
@@ -1281,7 +1281,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
         return ORKTimeOfDayDateFromComponents(self.defaultComponents);
     }
     
-    NSDateComponents *dateComponents = [[NSCalendar currentCalendar] componentsInTimeZone:[NSTimeZone systemTimeZone] fromDate:[NSDate date]];
+    NSDateComponents *dateComponents = [[NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian] componentsInTimeZone:[NSTimeZone systemTimeZone] fromDate:[NSDate date]];
     NSDateComponents *newDateComponents = [[NSDateComponents alloc] init];
     newDateComponents.calendar = ORKTimeOfDayReferenceCalendar();
     newDateComponents.hour = dateComponents.hour;
@@ -1382,7 +1382,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 }
 
 - (NSCalendar *)currentCalendar {
-    return (_calendar ? : [NSCalendar currentCalendar]);
+    return (_calendar ? : [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian]);
 }
 
 - (NSDateFormatter *)resultDateFormatter {
@@ -1422,7 +1422,7 @@ static NSArray *ork_processTextChoices(NSArray<ORKTextChoice *> *textChoices) {
 {
     if (!self.defaultDate)
     {
-        NSCalendar *calendar = [NSCalendar currentCalendar];
+        NSCalendar *calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
         NSCalendarUnit unitFlags = NSCalendarUnitYear | NSCalendarUnitMonth |  NSCalendarUnitDay;
         if (self.questionType == ORKQuestionTypeDateAndTime)
         {

--- a/ResearchKit/Common/ORKFormStepViewController.m
+++ b/ResearchKit/Common/ORKFormStepViewController.m
@@ -460,7 +460,7 @@
     }
     _savedAnswers[identifier] = answer;
     _savedAnswerDates[identifier] = [NSDate date];
-    _savedSystemCalendars[identifier] = [NSCalendar currentCalendar];
+    _savedSystemCalendars[identifier] = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
     _savedSystemTimeZones[identifier] = [NSTimeZone systemTimeZone];
 }
 
@@ -789,12 +789,11 @@
         
         id answer = ORKNullAnswerValue();
         NSDate *answerDate = now;
-        NSCalendar *systemCalendar = [NSCalendar currentCalendar];
+        NSCalendar *systemCalendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
         NSTimeZone *systemTimeZone = [NSTimeZone systemTimeZone];
         if (!_skipped) {
             answer = _savedAnswers[item.identifier];
             answerDate = _savedAnswerDates[item.identifier] ? : now;
-            systemCalendar = _savedSystemCalendars[item.identifier];
             NSAssert(answer == nil || answer == ORKNullAnswerValue() || systemCalendar != nil, @"systemCalendar NOT saved");
             systemTimeZone = _savedSystemTimeZones[item.identifier];
             NSAssert(answer == nil || answer == ORKNullAnswerValue() || systemTimeZone != nil, @"systemTimeZone NOT saved");
@@ -806,8 +805,7 @@
         if ([impliedAnswerFormat isKindOfClass:[ORKDateAnswerFormat class]]) {
             ORKDateQuestionResult *dqr = (ORKDateQuestionResult *)result;
             if (dqr.dateAnswer) {
-                NSCalendar *usedCalendar = [(ORKDateAnswerFormat *)impliedAnswerFormat calendar] ? : systemCalendar;
-                dqr.calendar = [NSCalendar calendarWithIdentifier:usedCalendar.calendarIdentifier];
+                dqr.calendar = systemCalendar;
                 dqr.timeZone = systemTimeZone;
             }
         } else if ([impliedAnswerFormat isKindOfClass:[ORKNumericAnswerFormat class]]) {

--- a/ResearchKit/Common/ORKHealthAnswerFormat.m
+++ b/ResearchKit/Common/ORKHealthAnswerFormat.m
@@ -187,7 +187,7 @@ NSString *ORKHKBloodTypeString(HKBloodType bloodType) {
             _impliedAnswerFormat = format;
             
         } else if ([identifier isEqualToString:HKCharacteristicTypeIdentifierDateOfBirth]) {
-            NSCalendar *calendar = _calendar ? : [NSCalendar currentCalendar];
+            NSCalendar *calendar = _calendar ? : [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
             NSDate *now = [NSDate date];
             NSDate *defaultDate = _defaultDate ? : [calendar dateByAddingUnit:NSCalendarUnitYear value:-35 toDate:now options:0];
             NSDate *minimumDate = _minimumDate ? : [calendar dateByAddingUnit:NSCalendarUnitYear value:-150 toDate:now options:0];

--- a/ResearchKit/Common/ORKQuestionStepViewController.m
+++ b/ResearchKit/Common/ORKQuestionStepViewController.m
@@ -83,10 +83,7 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
     ORKStepHeaderView *_headerView;
     ORKNavigationContainerView *_navigationFooterView;
     ORKAnswerDefaultSource *_defaultSource;
-    
-    NSCalendar *_savedSystemCalendar;
-    NSTimeZone *_savedSystemTimeZone;
-    
+        
     ORKTextChoiceCellGroup *_choiceCellGroup;
     ORKQuestionStepCellHolderView *_cellHolderView;
     
@@ -126,8 +123,9 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
 }
 
 - (instancetype)initWithStep:(ORKStep *)step result:(ORKResult *)result {
-    self = [self initWithStep:step];
+    self = [super initWithStep:step];
     if (self) {
+        _defaultSource = [ORKAnswerDefaultSource sourceWithHealthStore:[HKHealthStore new]];
 		ORKStepResult *stepResult = (ORKStepResult *)result;
 		if (stepResult && [stepResult results].count > 0) {
             ORKQuestionResult *questionResult = ORKDynamicCast([stepResult results].firstObject, ORKQuestionResult);
@@ -555,9 +553,8 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
         if ([impliedAnswerFormat isKindOfClass:[ORKDateAnswerFormat class]]) {
             ORKDateQuestionResult *dateQuestionResult = (ORKDateQuestionResult *)result;
             if (dateQuestionResult.dateAnswer) {
-                NSCalendar *usedCalendar = [(ORKDateAnswerFormat *)impliedAnswerFormat calendar] ? : _savedSystemCalendar;
-                dateQuestionResult.calendar = [NSCalendar calendarWithIdentifier:usedCalendar.calendarIdentifier ? : [NSCalendar currentCalendar].calendarIdentifier];
-                dateQuestionResult.timeZone = _savedSystemTimeZone ? : [NSTimeZone systemTimeZone];
+                dateQuestionResult.calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+                dateQuestionResult.timeZone = [NSTimeZone systemTimeZone];
             }
         } else if ([impliedAnswerFormat isKindOfClass:[ORKNumericAnswerFormat class]]) {
             ORKNumericQuestionResult *nqr = (ORKNumericQuestionResult *)result;
@@ -588,8 +585,6 @@ typedef NS_ENUM(NSInteger, ORKQuestionSection) {
 
 - (void)saveAnswer:(id)answer {
     self.answer = answer;
-    _savedSystemCalendar = [NSCalendar currentCalendar];
-    _savedSystemTimeZone = [NSTimeZone systemTimeZone];
     [self notifyDelegateOnResultChange];
 }
 


### PR DESCRIPTION
PATIOS-3679 Additional Gregorian Calendar updates

Apple designed RK to be flexible and let the Calendar used be derived from the device locale. This caused some bugs over the years for Medable, as it was never explicitly a requirement to use Gregorian EXCLUSIVELY until about a year ago. We're still addressing outlying cases around this in our older versions. It seems that a Swift <-> Objective-C interoperability misunderstanding when using a 'swizzling' technique to override standard functions left it so that Objective-C references to the currentCalendar still picked up the device calendar instead of the Swift swizzled current for NSCalendar.